### PR TITLE
Fixing memory leaks in the SWIG wrapper.

### DIFF
--- a/SWIG/_bio.i
+++ b/SWIG/_bio.i
@@ -121,20 +121,21 @@ PyObject *bio_gets(BIO *bio, int num) {
 }
 
 int bio_write(BIO *bio, PyObject *from) {
-    const void *fbuf;
-    int flen, ret;
+    Py_buffer fbuf;
+    int ret;
 
-    if (m2_PyObject_AsReadBufferInt(from, &fbuf, &flen) == -1)
-        return -1;
+    if (m2_PyObject_GetBufferInt(from, &fbuf, PyBUF_SIMPLE) == -1)
+      return -1;
 
     Py_BEGIN_ALLOW_THREADS
-    ret = BIO_write(bio, fbuf, flen);
+    ret = BIO_write(bio, fbuf.buf, fbuf.len);
     Py_END_ALLOW_THREADS
     if (ret < 0) {
         if (ERR_peek_error()) {
             PyErr_SetString(_bio_err, ERR_reason_error_string(ERR_get_error()));
         }
     }
+    m2_PyBuffer_Release(from, &fbuf);
     return ret;
 }
 
@@ -175,15 +176,20 @@ int bio_get_flags(BIO *bio) {
 }
 
 PyObject *bio_set_cipher(BIO *b, EVP_CIPHER *c, PyObject *key, PyObject *iv, int op) {
-    const void *kbuf, *ibuf;
-    Py_ssize_t klen, ilen;
+    Py_buffer kbuf, ibuf;
 
-    if ((PyObject_AsReadBuffer(key, &kbuf, &klen) == -1)
-        || (PyObject_AsReadBuffer(iv, &ibuf, &ilen) == -1))
-        return NULL;
+    if (m2_PyObject_GetBuffer(key, &kbuf, PyBUF_SIMPLE) == -1)
+      return NULL;
+
+    if (m2_PyObject_GetBuffer(iv, &ibuf, PyBUF_SIMPLE) == -1) {
+      m2_PyBuffer_Release(key, &kbuf);
+      return NULL;
+    }
 
     BIO_set_cipher(b, (const EVP_CIPHER *)c, 
-        (unsigned char *)kbuf, (unsigned char *)ibuf, op);
+        (unsigned char *)kbuf.buf, (unsigned char *)ibuf.buf, op);
+    m2_PyBuffer_Release(iv, &ibuf);
+    m2_PyBuffer_Release(key, &kbuf);
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/SWIG/_lib.i
+++ b/SWIG/_lib.i
@@ -47,25 +47,70 @@ void blob_free(Blob *blob) {
 /* Python helpers. */
 
 %}
-%ignore m2_PyObject_AsReadBufferInt;
+%ignore PyBuffer_Release;
+%ignore PyObject_CheckBuffer;
+%ignore PyObject_GetBuffer;
+%ignore m2_PyBuffer_Release;
+%ignore m2_PyObject_GetBuffer;
+%ignore m2_PyObject_GetBufferInt;
 %ignore m2_PyString_AsStringAndSizeInt;
 %{
-static int
-m2_PyObject_AsReadBufferInt(PyObject *obj, const void **buffer,
-                int *buffer_len)
-{
-    int ret;
-    Py_ssize_t len;
 
-    ret = PyObject_AsReadBuffer(obj, buffer, &len);
-    if (ret)
-        return ret;
-    if (len > INT_MAX) {
-        PyErr_SetString(PyExc_ValueError, "object too large");
-        return -1;
-    }
-    *buffer_len = len;
+
+#if PY_VERSION_HEX < 0x02060000
+static int PyObject_CheckBuffer(PyObject *obj) {
+    (void)obj;
     return 0;
+}
+
+static int PyObject_GetBuffer(PyObject *obj, Py_buffer *view, int flags) {
+    (void)obj;
+    (void)view;
+    (void)flags;
+    return -1;
+}
+
+static void PyBuffer_Release(Py_buffer *view) {
+    (void)view;
+}
+#endif /* PY_VERSION_HEX < 0x02060000 */
+
+
+static void m2_PyBuffer_Release(PyObject *obj, Py_buffer *view) {
+  if (PyObject_CheckBuffer(obj))
+    PyBuffer_Release(view);
+  /* else do nothing, view->buf comes from PyObject_AsReadBuffer */
+}
+
+static int m2_PyObject_GetBuffer(PyObject *obj, Py_buffer *view, int flags) {
+  int ret;
+
+  if (PyObject_CheckBuffer(obj))
+    ret = PyObject_GetBuffer(obj, view, flags);
+  else {
+    const void *buf;
+
+    ret = PyObject_AsReadBuffer(obj, &buf, &view->len);
+
+    if (ret == 0)
+      view->buf = (void *)buf;
+  }
+  return ret;
+}
+
+
+static int m2_PyObject_GetBufferInt(PyObject *obj, Py_buffer *view, int flags) {
+  int ret;
+
+  ret = m2_PyObject_GetBuffer(obj, view, flags);
+  if (ret)
+    return ret;
+  if (view->len > INT_MAX) {
+    PyErr_SetString(PyExc_ValueError, "object too large");
+    m2_PyBuffer_Release(obj, view);
+    return -1;
+  }
+  return 0;
 }
 
 static int
@@ -73,7 +118,6 @@ m2_PyString_AsStringAndSizeInt(PyObject *obj, char **s, int *len)
 {
     int ret;
     Py_ssize_t len2;
-
     ret = PyString_AsStringAndSize(obj, s, &len2);
     if (ret)
        return ret;
@@ -318,13 +362,15 @@ PyObject *bn_to_mpi(BIGNUM *bn) {
 }
 
 BIGNUM *mpi_to_bn(PyObject *value) {
-    const void *vbuf;
-    int vlen;
+    Py_buffer vbuf;
+    BIGNUM *ret;
 
-    if (m2_PyObject_AsReadBufferInt(value, &vbuf, &vlen) == -1)
-        return NULL;
+    if (m2_PyObject_GetBufferInt(value, &vbuf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
-    return BN_mpi2bn(vbuf, vlen, NULL);
+    ret = BN_mpi2bn(vbuf.buf, vbuf.len, NULL);
+    m2_PyBuffer_Release(value, &vbuf);
+    return ret;
 }
 
 PyObject *bn_to_bin(BIGNUM *bn) {
@@ -344,13 +390,15 @@ PyObject *bn_to_bin(BIGNUM *bn) {
 }
 
 BIGNUM *bin_to_bn(PyObject *value) {
-    const void *vbuf;
-    int vlen;
+    Py_buffer vbuf;
+    BIGNUM *ret;
 
-    if (m2_PyObject_AsReadBufferInt(value, &vbuf, &vlen) == -1)
-        return NULL;
+    if (m2_PyObject_GetBufferInt(value, &vbuf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
-    return BN_bin2bn(vbuf, vlen, NULL);
+    ret = BN_bin2bn(vbuf.buf, vbuf.len, NULL);
+    m2_PyBuffer_Release(value, &vbuf);
+    return ret;
 }
 
 PyObject *bn_to_hex(BIGNUM *bn) {
@@ -372,44 +420,48 @@ PyObject *bn_to_hex(BIGNUM *bn) {
 }
 
 BIGNUM *hex_to_bn(PyObject *value) {
-    const void *vbuf;
-    Py_ssize_t vlen;
+    Py_buffer vbuf;
     BIGNUM *bn;
 
-    if (PyObject_AsReadBuffer(value, &vbuf, &vlen) == -1)
-        return NULL;
+    if (m2_PyObject_GetBuffer(value, &vbuf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
     if ((bn=BN_new())==NULL) {
         PyErr_SetString(PyExc_MemoryError, "hex_to_bn");
+        m2_PyBuffer_Release(value, &vbuf);
         return NULL;
     }
-    if (BN_hex2bn(&bn, (const char *)vbuf) <= 0) {
+    if (BN_hex2bn(&bn, (const char *)vbuf.buf) <= 0) {
         PyErr_SetString(PyExc_RuntimeError, 
               ERR_error_string(ERR_get_error(), NULL));
         BN_free(bn);
+        m2_PyBuffer_Release(value, &vbuf);
         return NULL;
     }
+    m2_PyBuffer_Release(value, &vbuf);
     return bn;
 }
 
 BIGNUM *dec_to_bn(PyObject *value) {
-    const void *vbuf;
-    Py_ssize_t vlen;
+    Py_buffer vbuf;
     BIGNUM *bn;
 
-    if (PyObject_AsReadBuffer(value, &vbuf, &vlen) == -1)
-        return NULL;
+    if (m2_PyObject_GetBuffer(value, &vbuf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
     if ((bn=BN_new())==NULL) {
       PyErr_SetString(PyExc_MemoryError, "dec_to_bn");
+      m2_PyBuffer_Release(value, &vbuf);
       return NULL;
     }
-    if ((BN_dec2bn(&bn, (const char *)vbuf) <= 0)) {
+    if ((BN_dec2bn(&bn, (const char *)vbuf.buf) <= 0)) {
       PyErr_SetString(PyExc_RuntimeError, 
             ERR_error_string(ERR_get_error(), NULL));
       BN_free(bn);
+      m2_PyBuffer_Release(value, &vbuf);
       return NULL;
     }
+    m2_PyBuffer_Release(value, &vbuf);
     return bn;
 }
 %}

--- a/SWIG/_rand.i
+++ b/SWIG/_rand.i
@@ -26,25 +26,25 @@ void rand_init(PyObject *rand_err) {
 }
 
 PyObject *rand_seed(PyObject *seed) {
-    const void *buf;
-    int len;
+    Py_buffer buf;
 
-    if (m2_PyObject_AsReadBufferInt(seed, &buf, &len) == -1)
+    if (m2_PyObject_GetBufferInt(seed, &buf, PyBUF_SIMPLE) == -1)
         return NULL;
 
-    RAND_seed(buf, len);
+    RAND_seed(buf.buf, buf.len);
+    m2_PyBuffer_Release(seed, &buf);
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 PyObject *rand_add(PyObject *blob, double entropy) {
-    const void *buf;
-    int len;
+    Py_buffer buf;
 
-    if (m2_PyObject_AsReadBufferInt(blob, &buf, &len) == -1)
+    if (m2_PyObject_GetBufferInt(blob, &buf, PyBUF_SIMPLE) == -1)
         return NULL;
 
-    RAND_add(buf, len, entropy);
+    RAND_add(buf.buf, buf.len, entropy);
+    m2_PyBuffer_Release(blob, &buf);
     Py_INCREF(Py_None);
     return Py_None;
 }

--- a/SWIG/_ssl.i
+++ b/SWIG/_ssl.i
@@ -315,13 +315,14 @@ void ssl_ctx_set_verify(SSL_CTX *ctx, int mode, PyObject *pyfunc) {
 }
 
 int ssl_ctx_set_session_id_context(SSL_CTX *ctx, PyObject *sid_ctx) {
-    const void *buf;
-    int len;
+    Py_buffer buf;
+    int ret;
 
-    if (m2_PyObject_AsReadBufferInt(sid_ctx, &buf, &len) == -1)
-        return -1;
-
-    return SSL_CTX_set_session_id_context(ctx, buf, len);
+    if (m2_PyObject_GetBufferInt(sid_ctx, &buf, PyBUF_SIMPLE) == -1)
+      return -1;
+    ret = SSL_CTX_set_session_id_context(ctx, buf.buf, buf.len);
+    m2_PyBuffer_Release(sid_ctx, &buf);
+    return ret;
 }
 
 void ssl_ctx_set_info_callback(SSL_CTX *ctx, PyObject *pyfunc) {
@@ -384,13 +385,15 @@ void ssl_set_client_CA_list_from_context(SSL *ssl, SSL_CTX *ctx) {
 }
 
 int ssl_set_session_id_context(SSL *ssl, PyObject *sid_ctx) {
-    const void *buf;
-    int len;
+    Py_buffer buf;
+    int ret;
 
-    if (m2_PyObject_AsReadBufferInt(sid_ctx, &buf, &len) == -1)
-        return -1;
+    if (m2_PyObject_GetBufferInt(sid_ctx, &buf, PyBUF_SIMPLE) == -1)
+      return -1;
 
-    return SSL_set_session_id_context(ssl, buf, len);
+    ret = SSL_set_session_id_context(ssl, buf.buf, buf.len);
+    m2_PyBuffer_Release(sid_ctx, &buf);
+    return ret;
 }
 
 int ssl_set_fd(SSL *ssl, int fd) {
@@ -583,17 +586,14 @@ PyObject *ssl_read_nbio(SSL *ssl, int num) {
 }
 
 int ssl_write(SSL *ssl, PyObject *blob) {
-    const void *buf;
-    int len, r, err, ret;
+    int r, err, ret;
+    Py_buffer buf;
 
-
-    if (m2_PyObject_AsReadBufferInt(blob, &buf, &len) == -1) {
+    if (m2_PyObject_GetBufferInt(blob, &buf, PyBUF_SIMPLE) == -1)
         return -1;
-    }
 
-    
     Py_BEGIN_ALLOW_THREADS
-    r = SSL_write(ssl, buf, len);
+    r = SSL_write(ssl, buf.buf, buf.len);
     Py_END_ALLOW_THREADS
 
 
@@ -623,22 +623,19 @@ int ssl_write(SSL *ssl, PyObject *blob) {
             ret = -1;
     }
     
-    
+    m2_PyBuffer_Release(blob, &buf);
     return ret;
 }
 
 int ssl_write_nbio(SSL *ssl, PyObject *blob) {
-    const void *buf;
-    int len, r, err, ret;
+    int r, err, ret;
+    Py_buffer buf;
 
-
-    if (m2_PyObject_AsReadBufferInt(blob, &buf, &len) == -1) {
+    if (m2_PyObject_GetBufferInt(blob, &buf, PyBUF_SIMPLE) == -1)
         return -1;
-    }
-
     
     Py_BEGIN_ALLOW_THREADS
-    r = SSL_write(ssl, buf, len);
+    r = SSL_write(ssl, buf.buf, buf.len);
     Py_END_ALLOW_THREADS
     
     
@@ -667,7 +664,7 @@ int ssl_write_nbio(SSL *ssl, PyObject *blob) {
             ret = -1;
     }
     
-    
+    m2_PyBuffer_Release(blob, &buf);
     return ret;
 }
 

--- a/SWIG/_util.i
+++ b/SWIG/_util.i
@@ -17,41 +17,43 @@ void util_init(PyObject *util_err) {
     
 PyObject *util_hex_to_string(PyObject *blob) {
     PyObject *obj;
-    const void *buf;
     char *ret;
-    Py_ssize_t len;
+    Py_buffer buf;
 
-    if (PyObject_AsReadBuffer(blob, &buf, &len) == -1)
-        return NULL;
+    if (m2_PyObject_GetBuffer(blob, &buf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
-    ret = hex_to_string((unsigned char *)buf, len);
+    ret = hex_to_string((unsigned char *)buf.buf, buf.len);
     if (!ret) {
         PyErr_SetString(_util_err, ERR_reason_error_string(ERR_get_error()));
+        m2_PyBuffer_Release(blob, &buf);
         return NULL;
     }
     obj = PyString_FromString(ret);
     OPENSSL_free(ret);
+    m2_PyBuffer_Release(blob, &buf);
     return obj;
 }
 
 PyObject *util_string_to_hex(PyObject *blob) {
     PyObject *obj;
-    const void *buf;
     unsigned char *ret;
-    Py_ssize_t len0;
     long len;
+    Py_buffer buf;
 
-    if (PyObject_AsReadBuffer(blob, &buf, &len0) == -1)
-        return NULL;
+    if (m2_PyObject_GetBuffer(blob, &buf, PyBUF_SIMPLE) == -1)
+      return NULL;
 
-    len = len0;
-    ret = string_to_hex((char *)buf, &len);
+    len = buf.len;
+    ret = string_to_hex((char *)buf.buf, &len);
     if (ret == NULL) {
         PyErr_SetString(_util_err, ERR_reason_error_string(ERR_get_error()));
+        m2_PyBuffer_Release(blob, &buf);
         return NULL;
     }
     obj = PyString_FromStringAndSize((char*)ret, len);
     OPENSSL_free(ret);
+    m2_PyBuffer_Release(blob, &buf);
     return obj;
 }
 %}


### PR DESCRIPTION
There are some memory leaks in the SWIG wrapper here that I'm trying to get fixed for a while already (see http://bugzilla.osafoundation.org/show_bug.cgi?id=13005 ).

We are using M2Crypto in GRR ( https://code.google.com/p/grr/ ) and without this patch, it's basically unusable since we do lots of crypto operations and run out of memory immediately. We are providing a patch to fix this for our users but the installation process is a pain - having this fixed properly would be a huge win. Please have a look at this patch...